### PR TITLE
chore: onboard into the engineering org

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md — Agent Configuration for django-content-license
+
+<!-- Thin index only — bloat here = ignored instructions. Details live in the pointed-to
+     files. Scaffolded by forge-onboard; keep sections, replace placeholders. -->
+
+`django-content-license` is a reusable Django app that stores **License** records and
+attaches them to any model through a custom **LicenseField**, then renders attribution
+HTML for display. It targets research/academic and creative-content projects where correct
+licensing and attribution matter. See `CONTEXT.md` for the ubiquitous language.
+
+## Stack & commands
+
+- **Stack:** Python ≥3.10 / Django ≥3.2 (tested to 5.0), Poetry-managed. Ships to PyPI.
+- **Install:** `poetry install`
+- **Test:** `poetry run pytest` (or `python manage.py test`; settings module `tests.settings`)
+- **Lint:** `poetry run pre-commit run --all-files` (ruff + black + pyupgrade)
+- **Type-check:** `poetry run mypy licensing/`  *(currently non-blocking in CI)*
+- **Build:** `poetry build`
+- **All checks (as CI runs):** `poetry run invoke check`
+
+## Agent skills
+
+### Issue tracker
+
+Issues tracked in GitHub Issues via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix).
+See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` glossary at root, `docs/adr/` for standing decisions.
+See `docs/agents/domain.md`.
+
+### CI checks
+
+Required status checks the pipeline reads (exact names):
+`Code Quality`, `Security Scan`, `Build Package`, and the test matrix
+`Test Python 3.12, Django 4.2` (representative required combo; full matrix is 10 combos of
+Python 3.10–3.12 × Django 3.2/4.1/4.2/5.0). CI is repo-native; see the org's CI audit record
+in the registry.
+
+## Engineering org
+
+This repo is operated by the autonomous engineering org (Forge). Feature work runs
+spec→plan→tasks→implement→review→PR through org-side skills — there is no Spec Kit install
+here; `specs/NNN-slug/` directories are generated per feature. Constitution:
+`memory/constitution.md`. Budget overrides: none.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,99 @@
+# Django Content License — Domain Model
+
+<!-- Ubiquitous language for this repo. Drafted by forge-onboard from the source (not the
+     README, which currently over-describes the code — see "Open questions"). Terms marked
+     [CONFIRM] need Sam's ruling before they are load-bearing. -->
+
+## Glossary
+
+### License
+
+A stored record describing a single content license (e.g. MIT, CC-BY-4.0). Persisted as the
+`License` model, not a static enum or external registry: the project deliberately keeps the
+full license **text**, a human **description**, and a **canonical URL** in the database so a
+deployment owns its own license catalogue. Identified to users by **name** (unique) and by
+**slug** (auto-generated, unique). Has a lifecycle (see **License Lifecycle**).
+
+### Canonical URL
+
+The permanent online resource describing a license (unique per `License`). It is the href
+used when rendering attribution, and the stable external identity of the license — distinct
+from the internal **slug**.
+
+### License Lifecycle
+
+A `License` is either **active** (`is_active=True`, still recommended for use) or
+**deprecated** (`is_active=False`, with a required **deprecated date**). The two states are
+mutually exclusive and enforced in `License.clean()`: a deprecated license *must* carry a
+deprecated date; an active license *must not*. Deprecation is the retirement mechanism —
+licenses are not deleted (see **Protect-on-delete**).
+
+### Recommended License
+
+An active license. `License.get_recommended_licenses()` returns all `is_active=True`
+licenses, name-ordered — the set a project should offer for *new* content.
+
+### LicenseField
+
+A custom `ForeignKey` (`licensing.fields.LicenseField`) that points any model at a
+`License`. Defaults: `on_delete=PROTECT`, `verbose_name="license"`, a standard help text.
+Adding it to a model is the entire integration surface. Beyond the FK, it injects a
+**Display Method** onto the host model.
+
+### Display Method
+
+The `get_<fieldname>_display()` method that `LicenseField` auto-attaches to its host model
+(via `contribute_to_class`). Calling it renders the **Attribution Snippet** for that
+instance. Named to mirror Django's own `get_FOO_display()` convention. (Note: it *shadows*
+that convention's usual meaning — here it returns rendered HTML, not a choice label.)
+
+### Attribution
+
+The human-facing statement of who made a piece of content and under what license, assembled
+by `get_license_attribution()`. Its parts: **title** (str of the instance), **link** (the
+instance's `get_absolute_url()` if any), **creators** (the instance's `creators` attribute,
+or "Unknown"), and **creators_link** (the creators' `get_absolute_url()` if any). Attribution
+reads these off the host model duck-typed — the host is not required to have them.
+
+### Attribution Snippet
+
+The rendered HTML fragment produced by the **Display Method**, via the
+`licensing/snippet.html` template. Overridable by shadowing that template path. This is the
+only thing most templates call.
+
+### Creators
+
+The author(s) of a licensed instance, read off the host model's `creators` attribute
+(string or related object). Optional; absent creators render as "Unknown". Note the plural —
+`creators` (attribution) is distinct from the singular `creator` read by
+`get_license_creator()`. [CONFIRM] whether both are intended or the singular is legacy.
+
+### Slug
+
+The URL-safe unique identifier auto-generated from a license's **name** on save, with a
+numeric suffix to guarantee uniqueness. Internal identity for routing; contrast **Canonical
+URL** (external identity).
+
+### Protect-on-delete
+
+The policy (`on_delete=PROTECT` default on `LicenseField`) that a `License` referenced by any
+content cannot be deleted — retirement happens through the **License Lifecycle**
+(deprecation), never deletion.
+
+## Synonyms to avoid
+
+- **"license" as a field name** — collides with the Python builtin and reads badly; the
+  bundled example model uses `content_license`. Prefer a qualified name in host models.
+- **"license type" / "license kind"** — there is no license-type concept; a `License` is a
+  flat record. Don't introduce categorisation vocabulary that the model doesn't have.
+- **"delete a license"** — the domain retires licenses via **deprecation**; avoid "delete".
+
+## Open questions (for Sam — resolve before first feature spec)
+
+1. **README ↔ code drift.** The README documents features absent from the source: template
+   tags, a package-level admin (`licensing/admin.py` does not exist), `License.get_compatibility_with()`,
+   several test files, and a ReadTheDocs site. Are these a **roadmap** (keep as goals) or
+   **stale docs** (prune)? This decides whether the terms enter the glossary.
+2. **`creator` vs `creators`** — one intended, or is one legacy? (see **Creators**).
+3. Is the stored-catalogue model (full text in DB) the intended long-term design, or a
+   placeholder for pulling from an external license registry (SPDX/Creative Commons)?

--- a/docs/adr/0001-licenses-as-database-catalogue.md
+++ b/docs/adr/0001-licenses-as-database-catalogue.md
@@ -1,0 +1,30 @@
+# ADR-0001 — Licenses are a per-deployment database catalogue
+
+- **Status:** Accepted (retroactive — recorded at onboarding 2026-07-15; confirm)
+- **Context date:** observed in `licensing/models.py`, `licensing/fixtures/creativecommons.json.gz`
+
+## Context
+
+Licenses could be modelled three ways: (a) a hardcoded enum/choices list, (b) references
+into an external registry (SPDX, the Creative Commons API) resolved at runtime, or (c) stored
+database records each deployment owns.
+
+## Decision
+
+Licenses are stored `License` model rows. Each row carries the full license **text**, a
+**description**, a **canonical URL**, and lifecycle state — the deployment owns its catalogue.
+A bundled fixture (`creativecommons.json.gz`) seeds the common Creative Commons set, but
+deployments are free to add, edit, and deprecate their own.
+
+## Consequences
+
+- Licenses are queryable, admin-editable, and translatable like any model — no network
+  dependency at render time.
+- The catalogue can drift from upstream (e.g. SPDX) — there is no sync mechanism. If upstream
+  fidelity becomes a requirement, that is a new feature, not a change here.
+- Seed data ships as a Django fixture; loading it is the deployment's choice.
+
+## Open question
+
+Is (c) the intended long-term design, or a stepping stone toward (b)? See CONTEXT.md open
+question 3.

--- a/docs/adr/0002-attribution-via-injected-display-method.md
+++ b/docs/adr/0002-attribution-via-injected-display-method.md
@@ -1,0 +1,33 @@
+# ADR-0002 — Attribution rendered via an injected display method + overridable template
+
+- **Status:** Accepted (retroactive — recorded at onboarding 2026-07-15; confirm)
+- **Context date:** observed in `licensing/fields.py`, `licensing/utils.py`, `licensing/templates/licensing/snippet.html`
+
+## Context
+
+Host models need to render a licensing/attribution statement. Options: a standalone template
+tag/filter (`{% license_attribution obj %}`), a mixin the host inherits, or behaviour attached
+by the field itself.
+
+## Decision
+
+`LicenseField.contribute_to_class` injects a `get_<fieldname>_display()` method onto the host
+model. Calling it renders `licensing/snippet.html` with the instance and its license. The
+template branches on which attribution parts are present (`get_absolute_url`, `creators`,
+`creators.get_absolute_url`) and is overridable by shadowing the template path. Host models
+opt in purely by declaring the field — no mixin, no template-tag import.
+
+## Consequences
+
+- Zero-ceremony integration: add the field, call `obj.get_<field>_display()` in a template.
+- The method name mirrors Django's `get_FOO_display()` but returns rendered **HTML**, not a
+  choice label — a deliberate convention echo that can surprise. Documented in CONTEXT.md.
+- Attribution reads `creators` / `get_absolute_url` duck-typed off the host; hosts are not
+  required to provide them, and missing parts degrade gracefully ("Unknown", no link).
+- The README references "template tags" that do not exist — this ADR is the actual mechanism.
+
+## Alternatives rejected
+
+- **Template tag library:** requires a `{% load %}` and passing the object explicitly; more
+  ceremony, and no natural place for per-field defaults.
+- **Model mixin:** forces inheritance and conflicts with hosts that already have a base class.

--- a/docs/adr/0003-retire-by-deprecation-not-deletion.md
+++ b/docs/adr/0003-retire-by-deprecation-not-deletion.md
@@ -1,0 +1,33 @@
+# ADR-0003 — Licenses are retired by deprecation, never deleted
+
+- **Status:** Accepted (retroactive — recorded at onboarding 2026-07-15; confirm)
+- **Context date:** observed in `licensing/models.py` (`clean()`, `is_active`, `deprecated_date`), `licensing/fields.py` (`on_delete=PROTECT`)
+
+## Context
+
+A license referenced by published content must not silently disappear — attribution already
+rendered and stored URLs must keep resolving. But licenses do fall out of recommendation
+(superseded versions, withdrawn licenses).
+
+## Decision
+
+Two mechanisms, enforced together:
+
+1. **Protect-on-delete.** `LicenseField` defaults to `on_delete=PROTECT`, so a referenced
+   `License` cannot be deleted.
+2. **Lifecycle deprecation.** A `License` is **active** (`is_active=True`, no deprecated date)
+   or **deprecated** (`is_active=False`, deprecated date required). `License.clean()` enforces
+   the mutual exclusion. `get_recommended_licenses()` returns only active licenses.
+
+## Consequences
+
+- Historical references stay valid indefinitely; retirement is a state change, not a delete.
+- Callers building "choose a license" UIs should filter to `get_recommended_licenses()` /
+  `is_active=True` (the bundled `LicenseField` example uses `limit_choices_to`).
+- `clean()` is the enforcement point — code paths that bypass validation (bulk updates,
+  direct `save()`) can still create an inconsistent state; treat `clean()` as the contract.
+
+## Non-negotiable
+
+Avoid the word "delete" for licenses in domain language — the operation is **deprecate**
+(see CONTEXT.md synonyms-to-avoid).

--- a/docs/agents/alignment-plan.md
+++ b/docs/agents/alignment-plan.md
@@ -1,0 +1,87 @@
+# Family Alignment Plan — django-content-license → django-mvp standard
+
+Recorded 2026-07-15 during forge-onboard, after studying the gold standard
+(`django-mvp` + the already-onboarded `django-easy-icons`, the closest same-shape sibling).
+Onboarding scaffolding (agent config, CONTEXT, ADRs, constitution) is done. This file is the
+tooling/CI migration backlog — execute once Sam rules on the three open decisions.
+
+## Open decisions (block execution)
+
+1. **Support matrix** — narrow to family standard (Django 5.2 + 6.0, Py 3.11–3.13, drops EOL
+   3.2/4.1/4.2 — breaking) · keep broad · or middle (4.2 LTS + 5.2 + 6.0). *Recommend: narrow.*
+2. **CI approach** — adopt `django-mvp/shared` reusable workflows · or modernize bespoke.
+   *Recommend: adopt shared.*
+3. **Sequencing** — two PRs (onboard now, align next) · or one combined PR. *Recommend: two.*
+
+## Delta 1 — CI workflows (adopt shared reusable workflows)
+
+Replace the bespoke `tests.yml` (80-line matrix) and `build.yml` with thin callers:
+
+```yaml
+# .github/workflows/tests.yml
+name: Tests
+on:
+  push: { branches: [main], paths: ['licensing/**','tests/**','pyproject.toml','poetry.lock','.github/workflows/tests.yml'] }
+  pull_request: { types: [opened, synchronize, reopened] }   # NO paths filter — required checks must always report
+  workflow_dispatch:
+jobs:
+  call-tests:
+    uses: django-mvp/shared/.github/workflows/tests.yml@main
+    with:
+      coverage-package: licensing
+      django-versions: '["5.2", "6.0"]'          # per decision 1
+      poetry-install-args: ''                      # licensing keeps tooling in dev group, not a test group
+    secrets: inherit
+```
+```yaml
+# .github/workflows/build.yml
+name: Build
+on:
+  push: { branches: [main], paths: ['licensing/**','pyproject.toml','poetry.lock','.pre-commit-config.yaml','.github/workflows/build.yml'] }
+  pull_request: { types: [opened, synchronize, reopened] }
+  workflow_dispatch:
+jobs:
+  call-build:
+    uses: django-mvp/shared/.github/workflows/build.yml@main
+    with: { source-dir: licensing }
+    secrets: inherit
+```
+Emitted check names (for the ruleset): `Test Python <py>, Django <dj>` (per matrix combo),
+`Code Quality`, `Security Scan`, `Build Package`. Also review family extras:
+`auto-merge-dependabot.yml`, `changelog.yml`, `docs.yml`, `on-release-main.yml` — the repo
+already has changelog/on-release/dependencies workflows; reconcile against the family versions.
+
+## Delta 2 — Dev tooling bundle (pyproject)
+
+Current dev group is nearly empty (pre-commit, coverage) → `pytest`/`mypy`/`deptry` not
+installed. Adopt the family bundle:
+```toml
+[tool.poetry.group.dev.dependencies]
+fairdm-dev-tools = { git = "https://github.com/FAIR-DM/dev-tools", extras = ["dev", "test"] }
+
+[tool.poetry.group.docs.dependencies]   # if aligning docs (README claims ReadTheDocs)
+fairdm-docs = { git = "https://github.com/FAIR-DM/fairdm-docs", extras = ["sphinx_book_theme"] }
+```
+This alone fixes the dead `mypy || true` / `deptry || true` CI steps (they were no-ops because
+the tools weren't installed). Add `--cov=licensing` to pytest `addopts`. Bump `[tool.black]`
+`target-version` and `[tool.ruff] target-version` off py37/py38 to py311+.
+
+## Delta 3 — pre-commit modernization
+
+Replace `.pre-commit-config.yaml` with the easy-icons version (swap `easy_icons` → `licensing`):
+modern pinned revs (pre-commit-hooks v6.0.0, pyupgrade v3.21.2, ruff v0.14.7, black 25.11.0,
+poetry 2.3.4), `poetry-lock` at manual stage, and **local `mypy` + `deptry` hooks**. CI `skip:`
+list excludes the local Poetry hooks.
+
+## Delta 4 — README ↔ code reconciliation (from CI audit + CONTEXT open questions)
+
+Not tooling, but part of "in line": prune or build the README's phantom features (template
+tags, package admin, `get_compatibility_with()`, pytest-only test files, ReadTheDocs). Decide
+per CONTEXT.md open question 1. Track as its own issue/spec.
+
+## Ruleset (onboarding completion gate — unchanged by the above)
+
+Apply `kit/github/ruleset.json` on `main` with the emitted check names, org credential,
+required approval, no force-push, empty bypass. django-easy-icons precedent: ruleset
+`main-protection` (id 18769881); approval count effectively gated by the merge button under a
+user-PAT identity until the GitHub App migration.

--- a/docs/agents/ci-audit.md
+++ b/docs/agents/ci-audit.md
@@ -1,0 +1,49 @@
+# CI Audit — django-content-license (forge-onboard, 2026-07-15)
+
+CI is repo-native. This records the audit against the org quality floor. Base branch `main`
+is **green today** (verified via check-runs API + local `manage.py test`: 95 tests pass).
+
+## Required (must be green to complete onboarding)
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Tests run on every PR | ✅ | `tests.yml` on `pull_request` (matrix, SQLite+Postgres) |
+| Lint runs on every PR | ✅ | `build.yml` → `Code Quality` job runs `pre-commit` (ruff + black) |
+| Build succeeds on every PR | ✅ | `build.yml` → `Build Package` job (`poetry build`) |
+| Check names recorded | ✅ | AGENTS.md → `## Agent skills > CI checks` |
+| Ruleset applied on default branch | ❌ **GAP** | No branch protection/ruleset exists yet — see proposal 1 |
+
+## Expected (gaps recorded as proposals)
+
+| Item | Status | Note |
+| --- | --- | --- |
+| Type-check on PR | ⚠️ | `mypy licensing/` runs `|| true` **and mypy is not a dev dependency** → dead step. Proposal 2 |
+| Coverage measured | ✅ | Codecov (`codecov/project`, `codecov/patch` green) |
+| CI green on default branch today | ✅ | check-runs API + local run |
+| No secret exposure in PR jobs | ✅ | Workflows use `pull_request` (not `pull_request_target`); PyPI publish is `on-release-main` only |
+
+## Proposals (fix in the repo's own idiom, each its own PR)
+
+1. **Apply the org ruleset** on `main`: required checks, required approval, no force-push,
+   empty bypass list. Blocks onboarding completion. Needs a required-checks strategy
+   (proposal 1a) and the org credential.
+   - **1a. Required-checks strategy.** The test matrix produces 10 differently-named checks
+     (`Test Python X, Django Y`) — brittle to require by name. Recommend adding a small
+     `checks-complete` aggregate job that `needs:` all matrix jobs, then require
+     `checks-complete` + `Code Quality` + `Security Scan` + `Build Package`. (Pilot repo
+     django-easy-icons uses this `checks-complete` pattern.)
+2. **Dead type-check/dep steps.** `mypy` and `deptry` are invoked with `|| true` but neither
+   is installed → they never actually run. Either add them to the dev group and make them
+   blocking (ratchet per constitution quality bar) or remove the steps. Recommend: add + fix
+   + make blocking as a follow-up feature.
+3. **Test-runner drift.** `pyproject.toml` configures `[tool.pytest.ini_options]` and the
+   README references pytest-only test files (`test_pytest_*.py`, `test_integration.py`) that
+   do not exist; the actual suite runs under `manage.py test`. Align: either adopt pytest as
+   a real dev dep or drop the pytest config + README claims.
+4. **`Update Dependencies` workflow failing on main** (`dependencies.yml`) — not a PR gate,
+   but red. Worth a triage pass.
+
+## Registry facts
+
+- `verify_adapter`: `poetry` (validated — `poetry install` + `poetry run python manage.py test` → 95 pass)
+- Required check names (stable): `Code Quality`, `Security Scan`, `Build Package` (+ test matrix / future `checks-complete`)

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (this repo):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-....md
+│   └── 0002-....md
+└── licensing/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0002 (…) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Canonical role   | Label in our tracker | Meaning                                  |
+| ---------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`   | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`     | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`| `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`| `ready-for-human`    | Requires human implementation            |
+| `wontfix`        | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -1,0 +1,66 @@
+# django-content-license Constitution
+
+<!-- Authored at org onboarding (2026-07-15), mirroring the django-mvp family standard
+     (see django-easy-icons/memory/constitution.md). Changes go through the constitution
+     pathway (human-gated), never mid-feature. Read at the Constitution Check in /plan and
+     by reviewers. DRAFT: Article VI's concrete matrix pending Sam's support-matrix ruling. -->
+
+## Core articles (org defaults)
+
+### Article I — Test-First
+No implementation before a failing test exists for the behavior. Tests written by an
+Implementer for its own tasks; pre-existing tests are never modified or deleted without an
+approved decisions.md entry (tamper-check enforced).
+
+### Article II — Simplicity
+Start with the simplest design that satisfies the spec. New dependencies, new abstractions,
+and new infrastructure each require a stated justification in plan.md Complexity Tracking.
+YAGNI over speculation. This package is deliberately small (one model, one field, a handful
+of utils) — keep it that way.
+
+### Article III — Anti-Abstraction
+No wrapper layers, base classes, or "future-proofing" indirection without a present, concrete
+second use. Prefer duplication over the wrong abstraction.
+
+### Article IV — Integration-First
+Contracts and integration points are designed and tested before internals are polished.
+Acceptance scenarios exercise the package the way users touch it: `INSTALLED_APPS` config,
+declaring a `LicenseField` on a host model, and rendering attribution via
+`obj.get_<field>_display()`.
+
+## Project articles
+
+### Article V — Public API stability
+The public API is the `License` model, `LicenseField`, the injected `get_<field>_display()`
+contract, the `licensing/snippet.html` template, and the documented helpers in
+`licensing.utils`. Breaking changes to any of these require a deprecation path (warn one
+minor release before removal) and a CHANGELOG entry. Semver applies (currently 0.x: minor =
+may break with notice).
+
+### Article VI — Compatibility matrix
+Supported Python/Django versions are whatever the CI matrix declares — the matrix is
+authoritative. Policy: track actively-supported Django releases (family rule). New code must
+pass the full matrix; dropping a version is a constitution-level change recorded in CHANGELOG.
+<!-- [CONFIRM] concrete matrix: family standard is Django 5.2 LTS + 6.0, Python 3.11–3.13.
+     Pending Sam's ruling on narrowing from the current 3.2/4.1/4.2/5.0. -->
+
+### Article VII — Attribution & data-safety contract
+Rendered attribution MUST escape all interpolated values (host title, creators, license
+name/URL) — attribution HTML is only ever returned through Django's template layer +
+`mark_safe`, never hand-built string interpolation of model data. Licenses are retired by
+deprecation, never deletion (ADR-0003); migrations follow deprecate-then-remove and keep the
+bundled `creativecommons.json.gz` fixture loadable.
+
+## Quality bar
+
+- Coverage may not decrease (codecov tracks; the coverage matrix cell is the reference).
+- Every public API change updates README + CHANGELOG in the same PR.
+- `mypy licensing/` and `deptry` must be installed and pass (family standard runs both as
+  local pre-commit hooks + CI). Ratchet target: blocking, once the current dead `|| true`
+  steps are wired up (CI audit proposal 2).
+
+## Non-negotiables
+
+- One PR per feature; Sam merges; the org never merges.
+- Machine verification (tests/build/lint) gates every stage exit; no LLM judgment can
+  override a red gate.


### PR DESCRIPTION
One-time **forge-onboard** adoption of this repo into the autonomous engineering org. **Code is untouched** — this PR adds only agent config, domain docs, and the constitution.

## What's here
- **`AGENTS.md`** — thin agent-config index (stack, commands, skills, exact CI check names).
- **`docs/agents/`** — `issue-tracker.md`, `triage-labels.md`, `domain.md`, plus onboarding records `ci-audit.md` and `alignment-plan.md`.
- **`CONTEXT.md`** — ubiquitous-language glossary drafted from the source, synonyms-to-avoid, and open questions on README↔code drift.
- **`docs/adr/0001..0003`** — the standing decisions the code already embodies: per-deployment DB license catalogue; attribution via an injected `get_<field>_display()` + overridable template; retire-by-deprecation (never delete).
- **`memory/constitution.md`** — org articles + project articles, mirroring the django-mvp family standard (django-easy-icons).

## Notable findings (recorded, not fixed here)
- **README oversells the code**: template tags, a package-level admin, `License.get_compatibility_with()`, pytest-only test files, and a ReadTheDocs site are documented but absent. See `CONTEXT.md` open questions.
- **Dead CI steps**: `mypy` and `deptry` run with `|| true` but aren't installed → no-ops. See `docs/agents/ci-audit.md`.

## Follow-up — PR #2 (family alignment), tracked in `docs/agents/alignment-plan.md`
Adopt `django-mvp/shared` reusable CI workflows, the `fairdm-dev-tools` dev bundle, modern pre-commit, and narrow the support matrix to Django 5.2/6.0. That PR is where `verify.sh` goes fully green (it needs the toolchain this repo doesn't yet install).

## Base state
`main` is green today; 95 tests pass locally (Py3.14/Django5.2). A branch ruleset is being applied as part of onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)