### PR TITLE
docs: settle domain open questions (creators contract, catalogue design)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,9 +64,10 @@ only thing most templates call.
 ### Creators
 
 The author(s) of a licensed instance, read off the host model's `creators` attribute
-(string or related object). Optional; absent creators render as "Unknown". Note the plural —
-`creators` (attribution) is distinct from the singular `creator` read by
-`get_license_creator()`. [CONFIRM] whether both are intended or the singular is legacy.
+(string or related object). Optional; absent creators render as "Unknown". **`creators`
+(plural) is the canonical attribution contract** — it is what `get_license_attribution()` and
+`licensing/snippet.html` read. The singular `creator` read by `get_license_creator()` is a
+legacy orphan with no production caller and is slated for removal; do not build on it.
 
 ### Slug
 
@@ -88,12 +89,14 @@ content cannot be deleted — retirement happens through the **License Lifecycle
   flat record. Don't introduce categorisation vocabulary that the model doesn't have.
 - **"delete a license"** — the domain retires licenses via **deprecation**; avoid "delete".
 
-## Open questions (for Sam — resolve before first feature spec)
+## Resolved decisions (settled 2026-07-15)
 
-1. **README ↔ code drift.** The README documents features absent from the source: template
-   tags, a package-level admin (`licensing/admin.py` does not exist), `License.get_compatibility_with()`,
-   several test files, and a ReadTheDocs site. Are these a **roadmap** (keep as goals) or
-   **stale docs** (prune)? This decides whether the terms enter the glossary.
-2. **`creator` vs `creators`** — one intended, or is one legacy? (see **Creators**).
-3. Is the stored-catalogue model (full text in DB) the intended long-term design, or a
-   placeholder for pulling from an external license registry (SPDX/Creative Commons)?
+1. **README ↔ code drift** — RESOLVED (stale docs, pruned in PR #27). The phantom features
+   (template tags, package admin, `get_compatibility_with()`, ghost test files, ReadTheDocs)
+   were removed from the README rather than kept as roadmap.
+2. **`creator` vs `creators`** — RESOLVED: `creators` (plural) is canonical; the singular
+   `creator` / `get_license_creator()` is a legacy orphan to be removed (see **Creators**).
+3. **Stored-catalogue vs external registry** — RESOLVED: the per-deployment stored catalogue
+   is the intended design (ADR-0001, Accepted). `creativecommons.json.gz` is optional seed
+   data, not a sync. Pulling from an external registry (SPDX / Creative Commons API) would be
+   a future feature superseding ADR-0001, not the current direction.

--- a/docs/adr/0001-licenses-as-database-catalogue.md
+++ b/docs/adr/0001-licenses-as-database-catalogue.md
@@ -1,6 +1,6 @@
 # ADR-0001 — Licenses are a per-deployment database catalogue
 
-- **Status:** Accepted (retroactive — recorded at onboarding 2026-07-15; confirm)
+- **Status:** Accepted (confirmed by Sam 2026-07-15)
 - **Context date:** observed in `licensing/models.py`, `licensing/fixtures/creativecommons.json.gz`
 
 ## Context
@@ -24,7 +24,9 @@ deployments are free to add, edit, and deprecate their own.
   fidelity becomes a requirement, that is a new feature, not a change here.
 - Seed data ships as a Django fixture; loading it is the deployment's choice.
 
-## Open question
+## Resolution
 
-Is (c) the intended long-term design, or a stepping stone toward (b)? See CONTEXT.md open
-question 3.
+Confirmed as the intended long-term design (option c), not a stepping stone toward an external
+registry (Sam, 2026-07-15). The bundled `creativecommons.json.gz` is optional seed data loaded
+at the deployment's choice — there is no sync. Integrating an external registry (SPDX / the
+Creative Commons API) would be a future feature that supersedes this ADR, not a revision of it.

--- a/docs/adr/0004-creators-is-the-attribution-contract.md
+++ b/docs/adr/0004-creators-is-the-attribution-contract.md
@@ -1,0 +1,32 @@
+# ADR-0004 — `creators` (plural) is the attribution contract; the singular `creator` helper is retired
+
+- **Status:** Accepted (Sam, 2026-07-15)
+- **Context date:** observed in `licensing/utils.py`, `licensing/templates/licensing/snippet.html`
+
+## Context
+
+Two creator accessors coexist in the code with no clear relationship:
+
+- **`creators`** (plural) — read by `get_license_attribution()` and by `snippet.html` to render
+  the "by <creators>" clause. This is the live attribution path.
+- **`creator`** (singular) — read only by `get_license_creator()`, which returns
+  `getattr(instance, "creator", None)`. Nothing in `licensing/`, the templates, or the bundled
+  `example/` app calls `get_license_creator()`; it is exercised only by its own unit test.
+
+Carrying two overlapping names for "who made this" invites host models to wire the wrong one
+and get silently empty attribution.
+
+## Decision
+
+`creators` (plural) is the single canonical attribution contract. Host models expose a
+`creators` attribute (a string, or a related object with `get_absolute_url()`); attribution and
+the snippet read only that. `get_license_creator()` and the singular `creator` attribute are
+**legacy orphans** and will be removed (deprecate, then delete with its test in a follow-up
+change). No new code should read singular `creator`.
+
+## Consequences
+
+- One name to document and support; the glossary (CONTEXT.md → **Creators**) pins `creators`.
+- Removing `get_license_creator()` is a public-symbol removal — it ships under the deprecation
+  policy (Constitution Article V): warn one minor release before deletion, CHANGELOG entry.
+- Until removed, the orphan is harmless but must not be built upon.


### PR DESCRIPTION
**Summary** — Settles the two domain questions left open from onboarding, with Sam's rulings. Doc-only.

**Change**
- **`creators` is the attribution contract.** CONTEXT.md → *Creators* now states `creators` (plural) is canonical (what `get_license_attribution()` + `snippet.html` actually read); the singular `creator` / `get_license_creator()` is a legacy orphan (no production caller — only its own test) slated for removal. New **ADR-0004** records the decision + deprecation path.
- **Stored catalogue is the design.** **ADR-0001** status lifted from *"confirm"* → **Accepted**, with a resolution note: `creativecommons.json.gz` is optional seed data, not a sync; external SPDX/CC integration would be a future feature superseding the ADR.
- CONTEXT.md *Open questions* → replaced with *Resolved decisions* (all three now closed; #1 README drift was PR #27).

**Verify evidence** — `verify.sh`: test **passed** (95), build **passed**; `tamper-check`: **clean (0 flags)**. Doc-only (`CONTEXT.md`, `docs/adr/0001`, new `docs/adr/0004`).

**Lane: quickfix** — single concern (settle domain docs), docs-only, no code/interface/data/security surface. Under the ceiling.

**Risk** — none to runtime.

**Follow-up (separate quickfix, not in scope):** actually remove the `get_license_creator()` orphan + its test, under the deprecation policy (Constitution Art. V). I can pick that up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)