### PR TITLE
docs: add GOALS.md (tiered directions) + README scope section

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -1,41 +1,25 @@
 # GOALS — django-content-license
 
-Standing directions this project steers toward, grouped by how essential they are. Directions
-are headings, not tasks: you steer toward them, you don't finish them. Each has a stable id
-(identity, never a rank) and, when it needs one, a status. The roadmap turns these into
-shippable work that cites the id, and feature specs cite a roadmap item that cites the id, so
-everything built traces back to a direction here. Progress lives in the roadmap; this file is
-the standing definition of what the package is and wants to become. Scope, non-goals, and
-design principles live in the README.
+Enduring goals this project pursues. Identity lives in the README; when work happens and which
+release delivers it lives in the roadmap — this file names no versions. A goal is a capability
+or quality you steer toward, not a task you complete: its id is stable, its importance is a tag
+that can change, and whether it has been addressed enough is judged through the roadmap, specs,
+and review rather than the goal itself.
 
-### Tiers (maturity, mapped to versions)
-- **MVP** — the floor of a usable product. When the MVP directions are met, the package cuts **v1.0**.
-- **Mature** — enhancements that make it complete and dependable, delivered across the **v1.x** line.
-- **Nice-to-have** — real wants and stray ideas; never makes the package incomplete. An accepted one becomes a **v2.0+** theme.
+**Importance** — `Essential`: not worth adopting without it · `Expected`: a complete,
+dependable version is expected to have it · `Aspirational`: a genuine want whose absence never
+makes the package incomplete.
 
-A direction keeps its id if it changes tier.
+**Status** — unmarked means accepted and live · `draft`: captured, not yet refined ·
+`rejected`: decided against, kept with a reason and an ADR link when it's a design stance.
 
-### Statuses
-Unmarked means accepted and live. Otherwise:
-- **draft** — captured, not yet refined or accepted.
-- **rejected** — decided against; kept with a reason, and a linked ADR when the call is a design stance.
+| ID | Goal | Importance | Status | Notes |
+|----|------|------------|--------|-------|
+| G1 | **Easy distribution** — installable from a package index, with versioned releases. | Essential | | |
+| G2 | **One-field integration** — licensing and attribution from a single model field and one template call, no bespoke code. | Essential | | |
+| G3 | **Flexible attribution** — each license expresses the attribution it requires, rather than one fixed style. | Expected | | |
+| G4 | **Human-manageable catalogue** — a site maintainer can add, edit, and deprecate licenses without touching code. | Expected | | |
+| G5 | **Real internal adoption** — the projects this was extracted from rely on it instead of their own licensing code. | Expected | | |
+| G6 | **A catalogue that stays current** — license text can track authoritative upstream sources without manual upkeep. | Aspirational | draft | 2026-07-16 — bundled set goes stale when upstream rewords; would supersede ADR-0001. |
 
-## MVP → v1.0
-- **D1 — Easy distribution.** Installable from a package index, with versioned releases.
-- **D2 — One-field integration.** Licensing and attribution from a single model field and one
-  template call, no bespoke code.
-
-## Mature → v1.x
-- **D3 — Flexible attribution.** Each license expresses the attribution it requires, rather
-  than one fixed style.
-- **D4 — Human-manageable catalogue.** A site maintainer can add, edit, and deprecate licenses
-  without touching code.
-- **D5 — Real internal adoption.** The projects this was extracted from rely on it instead of
-  their own licensing code.
-
-## Nice-to-have → v2.0+
-- **D6 — A catalogue that doesn't rot.** `draft`. License text refreshable from an upstream
-  registry (SPDX / Creative Commons) without hand-maintenance. _(2026-07-16 — the bundled set
-  goes stale when upstream rewords; would supersede ADR-0001.)_
-
-_Written 2026-07-16. Revise as the direction changes._
+_Written 2026-07-16. Revise as the goals change._

--- a/GOALS.md
+++ b/GOALS.md
@@ -1,0 +1,75 @@
+# GOALS — django-content-license
+
+## Purpose
+
+`django-content-license` is a generic Django app for associating a **License** with any
+model through a single `LicenseField`, and — where a license requires it — rendering an
+optional HTML **attribution** snippet on the page. It is the GitHub-style primitive: a
+picked-from catalogue of licenses, plus attribution, made reusable for any Django project.
+It exists because publishing content correctly needs licensing, and there was no good
+generic Django app for it — so instead of baking it into a larger framework, it lives
+standalone.
+
+## Problem & users
+
+**Problem.** Django projects that publish content — datasets, publications, creative work —
+need to state a license and, for some licenses, show correct attribution. There is no clean,
+generic app for this, so each project either hand-rolls it or bakes it into a larger
+framework.
+
+**Users.** Any Django developer or site maintainer who wants a repository-style license
+picker plus optional attribution, with a one-field integration and no bespoke licensing code.
+
+## Success signals
+
+- **The projects it was built for adopt it and delete their hand-rolled licensing code** —
+  the package earns its existence by replacing the thing it would otherwise be baked into.
+- **One-field integration works end-to-end** — a developer adds licensing + attribution to a
+  model with a single `LicenseField` and one template call, against a fresh project, with no
+  custom code.
+
+External pickup (PyPI installs, stars, third-party issues) is a welcome lagging indicator,
+not a target — it follows from doing the two above well.
+
+## Non-goals
+
+- **Citation / metadata export** (BibTeX, DataCite, CSL) — attribution here is an optional
+  HTML snippet for display, not a research-citation engine.
+- **License compatibility reasoning** ("can I combine CC-BY with GPL?") — a legal-reasoning
+  engine, a different product.
+- **Domain-specific requirements of any single consumer** — the app stays the generic
+  primitive; a project with special needs integrates them on its own side, not here.
+- **A fixed, CC-only attribution format** — attribution is per-license and configurable; CC
+  is only what motivated the feature (see Standing tensions).
+
+## Desired directions (not commitments)
+
+Wanted, not scheduled — recorded so future feature work has a target:
+
+- **Bundled admin** — an intuitive way for site maintainers to manage the catalogue and mark
+  licenses current vs. deprecated. (Supersedes today's deliberate "ships no `ModelAdmin`"
+  stance; a step forward, not a contradiction.)
+- **Fresher catalogue** — eventually sync from an external registry (e.g. SPDX / Creative
+  Commons) so the bundled seed set doesn't go stale when upstream text is reworded, without
+  manual upkeep. Would supersede ADR-0001, which remains the *current* design.
+
+## Appetite
+
+**Steady side-work** — actively maintained and improved as real needs pull it forward; never
+a flagship with its own roadmap sprints.
+
+## Standing tensions
+
+- **Generic vs. any single consumer's needs → generic wins.** Real-world requirements are
+  kept in mind, but when they collide with staying generic, the app stays the reusable
+  primitive and the consuming project integrates its own needs on top.
+- **Simplicity vs. flexibility → simplicity wins.** The whole value is the one-field, one-call
+  integration surface. A feature that buys flexibility by eroding that simplicity is the wrong
+  trade for this app.
+- **Attribution: fixed vs. configurable → configurable.** Any license may define the
+  attribution style it requires; licenses that need nothing beyond their title simply don't
+  use the attribution feature. CC style is a default, not a constraint.
+
+---
+
+_Produced via `/forge-goals` on 2026-07-16; revise by re-running it._

--- a/GOALS.md
+++ b/GOALS.md
@@ -2,73 +2,75 @@
 
 ## Purpose
 
-`django-content-license` is a generic Django app for associating a **License** with any
-model through a single `LicenseField`, and — where a license requires it — rendering an
-optional HTML **attribution** snippet on the page. It is the GitHub-style primitive: a
-picked-from catalogue of licenses, plus attribution, made reusable for any Django project.
-It exists because publishing content correctly needs licensing, and there was no good
-generic Django app for it — so instead of baking it into a larger framework, it lives
-standalone.
+`django-content-license` lets any Django model carry a content license, and where a license
+needs it, renders a small HTML attribution snippet for the page. Think of the license picker
+GitHub puts on a new repository, plus the attribution part that some licenses (like Creative
+Commons) ask you to show. It exists because a lot of projects need this and there was no good
+generic app for it, so instead of building it into a larger framework it lives on its own.
 
 ## Problem & users
 
-**Problem.** Django projects that publish content — datasets, publications, creative work —
-need to state a license and, for some licenses, show correct attribution. There is no clean,
-generic app for this, so each project either hand-rolls it or bakes it into a larger
-framework.
+Projects that publish content need to say what license it's under, and some licenses want a
+visible attribution line to go with it. Today you either write that yourself or inherit it
+from whatever framework you're on. This app is the small piece that just does it.
 
-**Users.** Any Django developer or site maintainer who wants a repository-style license
-picker plus optional attribution, with a one-field integration and no bespoke licensing code.
+It's for any Django developer or site maintainer who wants a license picker and optional
+attribution by adding one field to a model, without writing licensing code of their own.
 
 ## Success signals
 
-- **The projects it was built for adopt it and delete their hand-rolled licensing code** —
-  the package earns its existence by replacing the thing it would otherwise be baked into.
-- **One-field integration works end-to-end** — a developer adds licensing + attribution to a
-  model with a single `LicenseField` and one template call, against a fresh project, with no
-  custom code.
+The projects it was built for switch to it and delete the licensing code they were carrying.
+That's the honest test of whether it was worth pulling out.
 
-External pickup (PyPI installs, stars, third-party issues) is a welcome lagging indicator,
-not a target — it follows from doing the two above well.
+Adding it to a model takes one `LicenseField` and one template call, on a fresh project, with
+nothing hand-written. If that stops being true, the app has drifted from the point.
+
+PyPI installs, stars, and issues from people I don't know are nice to see, but I'm not
+building for them and won't chase them.
 
 ## Non-goals
 
-- **Citation / metadata export** (BibTeX, DataCite, CSL) — attribution here is an optional
-  HTML snippet for display, not a research-citation engine.
-- **License compatibility reasoning** ("can I combine CC-BY with GPL?") — a legal-reasoning
-  engine, a different product.
-- **Domain-specific requirements of any single consumer** — the app stays the generic
-  primitive; a project with special needs integrates them on its own side, not here.
-- **A fixed, CC-only attribution format** — attribution is per-license and configurable; CC
-  is only what motivated the feature (see Standing tensions).
+It doesn't export citations or metadata (BibTeX, DataCite, CSL). Attribution here is a bit of
+HTML to display, not a research-citation system.
 
-## Desired directions (not commitments)
+It doesn't reason about license compatibility (whether you can combine CC-BY with GPL, say).
+That's a legal engine and a different project.
 
-Wanted, not scheduled — recorded so future feature work has a target:
+It doesn't grow to fit one particular consumer. If a project has a special need, it wires that
+in on its own side and this app stays generic.
 
-- **Bundled admin** — an intuitive way for site maintainers to manage the catalogue and mark
-  licenses current vs. deprecated. (Supersedes today's deliberate "ships no `ModelAdmin`"
-  stance; a step forward, not a contradiction.)
-- **Fresher catalogue** — eventually sync from an external registry (e.g. SPDX / Creative
-  Commons) so the bundled seed set doesn't go stale when upstream text is reworded, without
-  manual upkeep. Would supersede ADR-0001, which remains the *current* design.
+And attribution isn't locked to the Creative Commons style. CC is what prompted the feature,
+but each license defines whatever attribution it requires.
+
+## Desired directions
+
+Things I want, not things that are scheduled. They're written down so future work has a target
+to aim at.
+
+A bundled admin, so a site maintainer can manage the catalogue and mark which licenses are
+current and which are deprecated. Today the app ships no `ModelAdmin` on purpose; this would
+move that forward.
+
+A way to keep the catalogue fresh by syncing from an external registry like SPDX or Creative
+Commons, so the bundled seed set doesn't go stale when upstream text changes and I don't have
+to hand-update it. That would replace the current design recorded in ADR-0001.
 
 ## Appetite
 
-**Steady side-work** — actively maintained and improved as real needs pull it forward; never
-a flagship with its own roadmap sprints.
+Steady side-work. I'll maintain it and improve it as real needs come up, but it isn't a
+flagship and won't get its own roadmap sprints.
 
 ## Standing tensions
 
-- **Generic vs. any single consumer's needs → generic wins.** Real-world requirements are
-  kept in mind, but when they collide with staying generic, the app stays the reusable
-  primitive and the consuming project integrates its own needs on top.
-- **Simplicity vs. flexibility → simplicity wins.** The whole value is the one-field, one-call
-  integration surface. A feature that buys flexibility by eroding that simplicity is the wrong
-  trade for this app.
-- **Attribution: fixed vs. configurable → configurable.** Any license may define the
-  attribution style it requires; licenses that need nothing beyond their title simply don't
-  use the attribution feature. CC style is a default, not a constraint.
+When staying generic pulls against one consumer's specific need, generic wins. I keep those
+needs in mind, but the consuming project integrates them on its side, not in here.
+
+When more flexibility would cost the one-field, one-call simplicity, simplicity wins. That
+simple integration is most of the value.
+
+Attribution stays configurable rather than fixed. A license defines the attribution it needs,
+and a license that only wants its title shown just doesn't use the feature. The CC style is a
+default, not a rule.
 
 ---
 

--- a/GOALS.md
+++ b/GOALS.md
@@ -74,4 +74,4 @@ default, not a rule.
 
 ---
 
-_Produced via `/forge-goals` on 2026-07-16; revise by re-running it._
+_Written 2026-07-16. Revise as the project's direction changes._

--- a/GOALS.md
+++ b/GOALS.md
@@ -1,77 +1,41 @@
 # GOALS — django-content-license
 
-## Purpose
+Standing directions this project steers toward, grouped by how essential they are. Directions
+are headings, not tasks: you steer toward them, you don't finish them. Each has a stable id
+(identity, never a rank) and, when it needs one, a status. The roadmap turns these into
+shippable work that cites the id, and feature specs cite a roadmap item that cites the id, so
+everything built traces back to a direction here. Progress lives in the roadmap; this file is
+the standing definition of what the package is and wants to become. Scope, non-goals, and
+design principles live in the README.
 
-`django-content-license` lets any Django model carry a content license, and where a license
-needs it, renders a small HTML attribution snippet for the page. Think of the license picker
-GitHub puts on a new repository, plus the attribution part that some licenses (like Creative
-Commons) ask you to show. It exists because a lot of projects need this and there was no good
-generic app for it, so instead of building it into a larger framework it lives on its own.
+### Tiers (maturity, mapped to versions)
+- **MVP** — the floor of a usable product. When the MVP directions are met, the package cuts **v1.0**.
+- **Mature** — enhancements that make it complete and dependable, delivered across the **v1.x** line.
+- **Nice-to-have** — real wants and stray ideas; never makes the package incomplete. An accepted one becomes a **v2.0+** theme.
 
-## Problem & users
+A direction keeps its id if it changes tier.
 
-Projects that publish content need to say what license it's under, and some licenses want a
-visible attribution line to go with it. Today you either write that yourself or inherit it
-from whatever framework you're on. This app is the small piece that just does it.
+### Statuses
+Unmarked means accepted and live. Otherwise:
+- **draft** — captured, not yet refined or accepted.
+- **rejected** — decided against; kept with a reason, and a linked ADR when the call is a design stance.
 
-It's for any Django developer or site maintainer who wants a license picker and optional
-attribution by adding one field to a model, without writing licensing code of their own.
+## MVP → v1.0
+- **D1 — Easy distribution.** Installable from a package index, with versioned releases.
+- **D2 — One-field integration.** Licensing and attribution from a single model field and one
+  template call, no bespoke code.
 
-## Success signals
+## Mature → v1.x
+- **D3 — Flexible attribution.** Each license expresses the attribution it requires, rather
+  than one fixed style.
+- **D4 — Human-manageable catalogue.** A site maintainer can add, edit, and deprecate licenses
+  without touching code.
+- **D5 — Real internal adoption.** The projects this was extracted from rely on it instead of
+  their own licensing code.
 
-The projects it was built for switch to it and delete the licensing code they were carrying.
-That's the honest test of whether it was worth pulling out.
+## Nice-to-have → v2.0+
+- **D6 — A catalogue that doesn't rot.** `draft`. License text refreshable from an upstream
+  registry (SPDX / Creative Commons) without hand-maintenance. _(2026-07-16 — the bundled set
+  goes stale when upstream rewords; would supersede ADR-0001.)_
 
-Adding it to a model takes one `LicenseField` and one template call, on a fresh project, with
-nothing hand-written. If that stops being true, the app has drifted from the point.
-
-PyPI installs, stars, and issues from people I don't know are nice to see, but I'm not
-building for them and won't chase them.
-
-## Non-goals
-
-It doesn't export citations or metadata (BibTeX, DataCite, CSL). Attribution here is a bit of
-HTML to display, not a research-citation system.
-
-It doesn't reason about license compatibility (whether you can combine CC-BY with GPL, say).
-That's a legal engine and a different project.
-
-It doesn't grow to fit one particular consumer. If a project has a special need, it wires that
-in on its own side and this app stays generic.
-
-And attribution isn't locked to the Creative Commons style. CC is what prompted the feature,
-but each license defines whatever attribution it requires.
-
-## Desired directions
-
-Things I want, not things that are scheduled. They're written down so future work has a target
-to aim at.
-
-A bundled admin, so a site maintainer can manage the catalogue and mark which licenses are
-current and which are deprecated. Today the app ships no `ModelAdmin` on purpose; this would
-move that forward.
-
-A way to keep the catalogue fresh by syncing from an external registry like SPDX or Creative
-Commons, so the bundled seed set doesn't go stale when upstream text changes and I don't have
-to hand-update it. That would replace the current design recorded in ADR-0001.
-
-## Appetite
-
-Steady side-work. I'll maintain it and improve it as real needs come up, but it isn't a
-flagship and won't get its own roadmap sprints.
-
-## Standing tensions
-
-When staying generic pulls against one consumer's specific need, generic wins. I keep those
-needs in mind, but the consuming project integrates them on its side, not in here.
-
-When more flexibility would cost the one-field, one-call simplicity, simplicity wins. That
-simple integration is most of the value.
-
-Attribution stays configurable rather than fixed. A license defines the attribution it needs,
-and a license that only wants its title shown just doesn't use the feature. The CC style is a
-default, not a rule.
-
----
-
-_Written 2026-07-16. Revise as the project's direction changes._
+_Written 2026-07-16. Revise as the direction changes._

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ A Django app that allows you to associate content licenses with model instances 
 - **Internationalization**: Full i18n support with translations
 - **Performance**: Optimized database queries and indexing
 
+## Scope & philosophy
+
+django-content-license is deliberately small: it stores licenses, attaches them to your
+models, and renders attribution where a license needs it. Think of the license picker GitHub
+puts on a new repository, plus the attribution some licenses (like Creative Commons) ask you
+to show.
+
+It stays generic on purpose. It is not a citation or metadata exporter (BibTeX, DataCite,
+CSL), not a license-compatibility checker, and not tied to any one project's needs or to the
+Creative Commons attribution style.
+
+When choices collide: generic beats specific, simplicity beats flexibility, and attribution
+stays configurable: a license defines what it needs, and one that only needs its title shown
+simply doesn't use the feature.
+
+Where it's headed is tracked in [GOALS.md](GOALS.md).
+
 ## Quick Start
 
 ### Installation


### PR DESCRIPTION
Adds `GOALS.md` and a README **Scope & philosophy** section, following the repo documentation model (three docs, distinct jobs).

## GOALS.md — standing directions, not tasks
- Maturity tiers mapped to versions: **MVP → v1.0**, **Mature → v1.x**, **Nice-to-have → v2.0+**.
- Directions carry **stable ids** (`D1`…) that are identity, not rank, and survive tier changes.
- Coarse lifecycle **statuses** only: `draft` / `rejected`; unmarked = live. No acceptance criteria (immeasurable), no progress tracking (that lives in the roadmap).
- The roadmap will cite these ids; feature specs cite a roadmap item that cites an id — everything built traces back to a direction.

## README — Scope & philosophy
The charter (purpose, non-goals, principles) now lives in the README, where adopters actually read it, rather than in GOALS.md where it duplicated the README intro.

Doc-only; no code, tests, or public API touched. The tier/status classifications are a first pass, open to refinement in a proper goals grill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)