### PR TITLE
fix: serialise mypy pre-commit hook (parallel batches race on .mypy_cache)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,9 @@ repos:
         name: mypy
         entry: poetry run mypy
         language: system
+        # --no-incremental avoids a compiled-mypy INTERNAL ERROR that fires during
+        # incremental-cache teardown *after* a successful check, flaking the CI gate.
+        args: [--no-incremental]
         types: [python]
         files: ^licensing/
       - id: deptry

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,9 +40,11 @@ repos:
         name: mypy
         entry: poetry run mypy
         language: system
-        # --no-incremental avoids a compiled-mypy INTERNAL ERROR that fires during
-        # incremental-cache teardown *after* a successful check, flaking the CI gate.
-        args: [--no-incremental]
+        # Without require_serial, pre-commit splits the file list into parallel
+        # batches, and concurrent mypy processes race on the shared .mypy_cache —
+        # INTERNAL ERROR on a cold cache (reproducible: rm -rf .mypy_cache, run
+        # --all-files). One serial invocation is also what mirrors-mypy ships.
+        require_serial: true
         types: [python]
         files: ^licensing/
       - id: deptry


### PR DESCRIPTION
## Summary
Fixes the intermittent `INTERNAL ERROR` from the mypy hook that keeps failing the required **Code Quality** check on unrelated PRs (seen on PR 30 and twice on PR 32).

## Root cause (now proven, not guessed)
Without `require_serial`, pre-commit splits the hook's file list into **parallel batches** — on this repo, 4 + 1 files — and runs **two concurrent mypy processes sharing one `.mypy_cache`**. On a cold cache (every CI run, since CI only caches `~/.cache/pre-commit`, not `.mypy_cache`) both processes write cache entries for the same modules and collide; one crashes with `INTERNAL ERROR` while the other prints `Success`. That concatenated output is exactly what the CI logs show. A warm local cache masks it, which is why it looked like a CI-only flake.

**Reproduced locally:** `rm -rf .mypy_cache && pre-commit run mypy --all-files` → same INTERNAL ERROR on the second attempt.

## Change
One hook setting in `.pre-commit-config.yaml`: `require_serial: true` on the mypy hook — a single mypy invocation over all files, no concurrent cache access. This is also what the official `mirrors-mypy` hook ships. (Replaces the earlier `--no-incremental` mitigation, which would also have worked but by disabling incremental mode entirely; this fix keeps incremental caching for local speed.)

## Verify evidence
- With the fix: **5/5 cold-cache runs pass** locally; without it, crash by attempt 2.
- typecheck/test/build passed; tamper-check clean. Config-only, no behaviour to test.

## Lane: quickfix
One line of hook config, single concern, no code/API/data/security surface.

## Risk
None identified — serialising the hook only affects hook execution strategy; mypy's results are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)