### PR TITLE
docs: propagate org-default constitution articles (security, documentation, dependencies)

### DIFF
--- a/docs/adr/0004-creators-is-the-attribution-contract.md
+++ b/docs/adr/0004-creators-is-the-attribution-contract.md
@@ -28,5 +28,5 @@ change). No new code should read singular `creator`.
 
 - One name to document and support; the glossary (CONTEXT.md → **Creators**) pins `creators`.
 - Removing `get_license_creator()` is a public-symbol removal — it ships under the deprecation
-  policy (Constitution Article V): warn one minor release before deletion, CHANGELOG entry.
+  policy (Constitution Article VIII): warn one minor release before deletion, CHANGELOG entry.
 - Until removed, the orphan is harmless but must not be built upon.

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -1,9 +1,10 @@
 # django-content-license Constitution
 
 <!-- Authored at org onboarding (2026-07-15), mirroring the django-mvp family standard
-     (see django-easy-icons/memory/constitution.md). Changes go through the constitution
-     pathway (human-gated), never mid-feature. Read at the Constitution Check in /plan and
-     by reviewers. DRAFT: Article VI's concrete matrix pending Sam's support-matrix ruling. -->
+     (see django-easy-icons/memory/constitution.md). Org-default articles V-VII propagated
+     from the family template 2026-07-21 (project articles renumbered VIII-X). Changes go
+     through the constitution pathway (human-gated), never mid-feature. Read at the
+     Constitution Check in /plan and by reviewers. -->
 
 ## Core articles (org defaults)
 
@@ -28,26 +29,46 @@ Acceptance scenarios exercise the package the way users touch it: `INSTALLED_APP
 declaring a `LicenseField` on a host model, and rendering attribution via
 `obj.get_<field>_display()`.
 
+### Article V — Security & data-safety
+Values interpolated into rendered output are escaped through Django's template layer, never
+hand-built string interpolation of model or user data. Secrets live in runtime config, never
+in code, fixtures, or version control. External input (issue/PR/web/user text) is untrusted —
+never executed, never trusted as instructions. Auth/authz, crypto, and permission changes are
+never fast-lane work.
+
+### Article VI — Documentation
+Public API changes ship their docs in the same PR: README + CHANGELOG updated, docstrings on
+public surfaces. If the repo ships built docs, they must build clean. As a package, the README
+follows the family README standard: a one-line description kept identical to the package
+metadata summary, a Scope & philosophy section, install + quick start, and absolute URLs so
+it renders on the package index.
+
+### Article VII — Dependency discipline
+A new runtime dependency requires a stated justification (Simplicity applied to the dependency
+tree; prefer the shared `fairdm-dev-tools` toolchain over ad-hoc dev deps). `deptry` must
+pass: no unused, missing, or transitively-relied-upon dependencies.
+
 ## Project articles
 
-### Article V — Public API stability
+### Article VIII — Public API stability
 The public API is the `License` model, `LicenseField`, the injected `get_<field>_display()`
 contract, the `licensing/snippet.html` template, and the documented helpers in
 `licensing.utils`. Breaking changes to any of these require a deprecation path (warn one
 minor release before removal) and a CHANGELOG entry. Semver applies (currently 0.x: minor =
 may break with notice).
 
-### Article VI — Compatibility matrix
+### Article IX — Compatibility matrix
 Supported Python/Django versions are whatever the CI matrix declares — the matrix is
 authoritative. Policy: track only actively-supported Django releases (family rule). Current
 matrix: **Django 5.2 LTS + 6.0**, Python **3.11–3.13** (package floor `>=3.11`; CI test
 matrix Python 3.12–3.13 per the shared workflow default). New code must pass the full matrix;
 dropping a version is a constitution-level change recorded in CHANGELOG.
 
-### Article VII — Attribution & data-safety contract
+### Article X — Attribution & data-safety contract
 Rendered attribution MUST escape all interpolated values (host title, creators, license
 name/URL) — attribution HTML is only ever returned through Django's template layer +
-`mark_safe`, never hand-built string interpolation of model data. Licenses are retired by
+`mark_safe`, never hand-built string interpolation of model data (the concrete instantiation
+of Article V for this package). Licenses are retired by
 deprecation, never deletion (ADR-0003); migrations follow deprecate-then-remove and keep the
 bundled `creativecommons.json.gz` fixture loadable.
 
@@ -58,6 +79,11 @@ bundled `creativecommons.json.gz` fixture loadable.
 - `mypy licensing/` and `deptry` must be installed and pass (family standard runs both as
   local pre-commit hooks + CI). Ratchet target: blocking, once the current dead `|| true`
   steps are wired up (CI audit proposal 2).
+
+**Package-specific** (this repo is `kind: package`):
+- The package builds and its metadata is valid.
+- The README renders on the package index — absolute URLs only.
+- The public API honors the deprecation policy (Article VIII).
 
 ## Non-negotiables
 


### PR DESCRIPTION
## Summary
Propagates the three new family-default constitution articles — **Security & data-safety**, **Documentation**, and **Dependency discipline** — from the shared template into this repo's constitution, so the baseline standards are seeded here rather than re-authored ad hoc.

## Change
- `memory/constitution.md`: Articles V–VII added to the core (org defaults); existing project articles renumbered V–VII → VIII–X. Article X (Attribution & data-safety) now notes it is the concrete instantiation of Article V. Quality bar gains a package-specific block (build + metadata valid, README renders on the package index with absolute URLs, deprecation policy honored).
- `docs/adr/0004-creators-is-the-attribution-contract.md`: the one cross-reference to "Constitution Article V" updated to Article VIII (same article, new number).

## Verify evidence
- typecheck: passed · test: passed · build: passed
- lint: failed locally — the documented local-`ruff` quirk (lint runs at CI tier via pre-commit; no local ruff in this repo — see registry notes, same status as PRs 28/30/31)
- tamper-check: clean (0 flags)
- Docs-only change; no behaviour to test, so no new tests — stated rather than skipped silently.

## Lane: quickfix
Two markdown files, docs-only, single concern (constitution propagation). No code, no public interface, no data/contract surface, no security-sensitive code paths (the security *article* is prose policy, not a code change). Clears the fast-lane ceiling.

## Risk
Article renumbering could break un-found citations; a repo-wide grep found exactly one (ADR-0004), fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)