### PR TITLE
docs: align constitution + AGENTS to family standard v0.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,10 @@ licensing and attribution matter. See `CONTEXT.md` for the ubiquitous language.
 ## Stack & commands
 
 - **Stack:** Python ≥3.11 / Django 5.2 LTS + 6.0 (family standard — supported releases only),
-  Poetry-managed. Dev toolchain via the `fairdm-dev-tools` bundle. Ships to PyPI.
+  Poetry-managed. Dev toolchain via the `mvp-shared` bundle. Ships to PyPI.
 - **Install:** `poetry install`
 - **Test:** `poetry run pytest` (pytest-django; settings module `tests.settings`)
-- **Lint/format:** `poetry run pre-commit run --all-files` (ruff + black + pyupgrade; local mypy + deptry hooks)
+- **Lint/format:** `poetry run pre-commit run --all-files` (ruff lint + ruff-format; local mypy + deptry hooks)
 - **Type-check:** `poetry run mypy licensing/`
 - **Build:** `poetry build`
 - **All checks (as CI runs):** `poetry run invoke check`

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -45,7 +45,7 @@ it renders on the package index.
 
 ### Article VII — Dependency discipline
 A new runtime dependency requires a stated justification (Simplicity applied to the dependency
-tree; prefer the shared `fairdm-dev-tools` toolchain over ad-hoc dev deps). `deptry` must
+tree; prefer the shared `mvp-shared` toolchain bundle over ad-hoc dev deps). `deptry` must
 pass: no unused, missing, or transitively-relied-upon dependencies.
 
 ## Project articles


### PR DESCRIPTION
**Summary** — Re-sync the materialized prose to the v0.2.0 toolchain adopted in #33; two files still named the retired bundle / an outdated lint stack.

**Change**
- `memory/constitution.md` Article VII: `fairdm-dev-tools` → `mvp-shared` toolchain bundle.
- `AGENTS.md` Stack block: dev toolchain via the `mvp-shared` bundle; lint/format command now reads `ruff lint + ruff-format` (black/pyupgrade were retired at v0.2.0). pyproject + pre-commit already match this.
- `docs/agents/alignment-plan.md` intentionally **not** changed — it is a historical onboarding record (Status: EXECUTED in PR #2); its mentions correctly describe the repo's state on 2026-07-15.

**Verify evidence** — `verify.sh`: lint passed · typecheck passed · test passed · build passed (4/4). tamper-check: clean (0 flags).

**Lane: quickfix** — Single-concern docs prose alignment across 2 files; no code, no public interface, no data/schema/security surface. Inside the fast-lane ceiling.

**Risk** — None. Prose-only; no behavioural change.