### PR TITLE
docs: correct ADR-0004 wording on the unused attribution helpers

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,8 +66,10 @@ only thing most templates call.
 The author(s) of a licensed instance, read off the host model's `creators` attribute
 (string or related object). Optional; absent creators render as "Unknown". **`creators`
 (plural) is the canonical attribution contract** — it is what `get_license_attribution()` and
-`licensing/snippet.html` read. The singular `creator` read by `get_license_creator()` is a
-legacy orphan with no production caller and is slated for removal; do not build on it.
+`licensing/snippet.html` read. The singular `creator` read by `get_license_creator()` has no
+production caller and is inconsistent with it; do not build on it. Whether it's removed, wired
+up, or reconciled with `creators` is deferred to goals grilling, not yet a scheduled removal
+(corrected 2026-07-30; see ADR-0004 Amendment).
 
 ### Slug
 
@@ -94,8 +96,10 @@ content cannot be deleted — retirement happens through the **License Lifecycle
 1. **README ↔ code drift** — RESOLVED (stale docs, pruned in PR #27). The phantom features
    (template tags, package admin, `get_compatibility_with()`, ghost test files, ReadTheDocs)
    were removed from the README rather than kept as roadmap.
-2. **`creator` vs `creators`** — RESOLVED: `creators` (plural) is canonical; the singular
-   `creator` / `get_license_creator()` is a legacy orphan to be removed (see **Creators**).
+2. **`creator` vs `creators`** — RESOLVED: `creators` (plural) is the canonical attribution
+   contract for the live render path. Whether the singular `creator` / `get_license_creator()`
+   is removed, wired up, or reconciled with it is not resolved — deferred to goals grilling
+   (see **Creators**; corrected 2026-07-30, see ADR-0004 Amendment).
 3. **Stored-catalogue vs external registry** — RESOLVED: the per-deployment stored catalogue
    is the intended design (ADR-0001, Accepted). `creativecommons.json.gz` is optional seed
    data, not a sync. Pulling from an external registry (SPDX / Creative Commons API) would be

--- a/docs/adr/0004-creators-is-the-attribution-contract.md
+++ b/docs/adr/0004-creators-is-the-attribution-contract.md
@@ -30,3 +30,20 @@ change). No new code should read singular `creator`.
 - Removing `get_license_creator()` is a public-symbol removal — it ships under the deprecation
   policy (Constitution Article VIII): warn one minor release before deletion, CHANGELOG entry.
 - Until removed, the orphan is harmless but must not be built upon.
+
+## Amendment (2026-07-30)
+
+Issue #29 flagged that "legacy orphans and will be removed" above overstates where this
+actually landed. No removal, wiring, or reconciliation has been decided or scheduled.
+
+The decision that holds today: `creators` (plural) remains the one attribution contract the
+render path reads. `get_license_creator()`, `get_license_attribution()`,
+`get_attribution_context()`, and `validate_license_field_name()` are unused outside their own
+tests, and the singular/plural naming is inconsistent. That's a thin, harmless gap on an Alpha
+package, not a defect worth a breaking change. Whether these helpers get removed, wired up,
+or reconciled with `creators` depends on the package's intended public API surface, which is a
+product-scope question for goals grilling to settle, not a foregone removal.
+
+This amendment supersedes the "legacy orphans and will be removed" line in **Decision** above;
+that original text is left in place as the historical record of what was accepted on
+2026-07-15.


### PR DESCRIPTION
## Summary

Corrects wording in ADR-0004 and CONTEXT.md that said the unused attribution helpers "will be removed", when no such removal was ever decided. Raised in #29.

## Changes

- `docs/adr/0004-creators-is-the-attribution-contract.md` — adds a dated amendment recording what actually holds: `creators` stays the attribution contract, the four unused helpers are a harmless gap on an Alpha package, and whether they get removed, wired up, or reconciled is an open question about the intended public API. The original line stays in place as the historical record of what was accepted on 2026-07-15.
- `CONTEXT.md` — corrects the two passages that repeated the same overstatement.

Documentation only. No code, no public symbols, no migrations.

## Verify evidence

`lint`, `typecheck`, `test`, `build` and `conformance` all passed; tamper-check clean with 0 flags.

The lint step is worth a note. On the first attempt it went red on four files under `tests/`, which this branch does not touch. That was a false alarm in the local tooling, not a problem with the branch: the checker was running ruff directly across the whole tree, while this repo's pre-commit configuration excludes `tests/` and CI honours that exclusion. The local checker now runs the repository's own pre-commit configuration, so it and CI ask the same question. The branch is green under both.

## Risk

None beyond the documentation itself. #29 stays open deliberately — it asks what should happen to the helpers, and that is a scope question rather than a wording fix.
