### PR TITLE
chore: pin shared workflows to v0.3.3

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Auto-merge Dependabot PR
-        uses: django-mvp/shared/.github/actions/auto-merge-dependabot@v0.2.0
+        uses: django-mvp/shared/.github/actions/auto-merge-dependabot@v0.3.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-url: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   call-build:
-    uses: django-mvp/shared/.github/workflows/build.yml@v0.2.0
+    uses: django-mvp/shared/.github/workflows/build.yml@v0.3.3
     with:
       source-dir: licensing
     secrets: inherit

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   call-prepare-release:
-    uses: django-mvp/shared/.github/workflows/prepare-release.yml@v0.2.0
+    uses: django-mvp/shared/.github/workflows/prepare-release.yml@v0.3.3
     with:
       bump: ${{ inputs.bump }}
     secrets:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   call-tag-release:
-    uses: django-mvp/shared/.github/workflows/tag-release.yml@v0.2.0
+    uses: django-mvp/shared/.github/workflows/tag-release.yml@v0.3.3
     secrets:
       release-token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   call-tests:
-    uses: django-mvp/shared/.github/workflows/tests.yml@v0.2.0
+    uses: django-mvp/shared/.github/workflows/tests.yml@v0.3.3
     with:
       coverage-package: licensing
       django-versions: '["5.2", "6.0"]'


### PR DESCRIPTION
Bumps all `django-mvp/shared/.github/...` references from v0.2.0 to v0.3.3.

Depends on [django-mvp/shared#36](https://github.com/django-mvp/shared/pull/36) merging and the v0.3.3 tag being cut — CI on this PR will not resolve the shared action/workflow refs until then. Hold merge until v0.3.3 exists.